### PR TITLE
ci: add skill-chain workflow

### DIFF
--- a/.claude/skills/write-a-prd/SKILL.md
+++ b/.claude/skills/write-a-prd/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: write-a-prd
+description: Create a PRD through user interview, codebase exploration, and module design, then submit as a GitHub issue. Use when user wants to write a PRD, create a product requirements document, or plan a new feature.
+---
+
+This skill will be invoked when the user wants to create a PRD. You may skip steps if you don't consider them necessary.
+
+1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
+
+2. Explore the repo to verify their assertions and understand the current state of the codebase.
+
+3. Interview the user relentlessly about every aspect of this plan until you reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+4. Sketch out the major modules you will need to build or modify to complete the implementation. Actively look for opportunities to extract deep modules that can be tested in isolation.
+
+A deep module (as opposed to a shallow module) is one which encapsulates a lot of functionality in a simple, testable interface which rarely changes.
+
+Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
+
+5. Once you have a complete understanding of the problem and solution, use the template below to write the PRD. The PRD should be submitted as a GitHub issue.
+
+<prd-template>
+
+## Problem Statement
+
+The problem that the user is facing, from the user's perspective.
+
+## Solution
+
+The solution to the problem, from the user's perspective.
+
+## User Stories
+
+A LONG, numbered list of user stories. Each user story should be in the format of:
+
+1. As an <actor>, I want a <feature>, so that <benefit>
+
+<user-story-example>
+1. As a mobile bank customer, I want to see balance on my accounts, so that I can make better informed decisions about my spending
+</user-story-example>
+
+This list of user stories should be extremely extensive and cover all aspects of the feature.
+
+## Implementation Decisions
+
+A list of implementation decisions that were made. This can include:
+
+- The modules that will be built/modified
+- The interfaces of those modules that will be modified
+- Technical clarifications from the developer
+- Architectural decisions
+- Schema changes
+- API contracts
+- Specific interactions
+
+Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+## Testing Decisions
+
+A list of testing decisions that were made. Include:
+
+- A description of what makes a good test (only test external behavior, not implementation details)
+- Which modules will be tested
+- Prior art for the tests (i.e. similar types of tests in the codebase)
+
+## Out of Scope
+
+A description of the things that are out of scope for this PRD.
+
+## Further Notes
+
+Any further notes about the feature.
+
+</prd-template>

--- a/.github/workflows/skill-chain.yml
+++ b/.github/workflows/skill-chain.yml
@@ -61,7 +61,7 @@ jobs:
             - Testing Strategy → Testing Decisions
             - Infer user stories from the RFC context
 
-            Create the PRD as a GitHub issue using the write-a-prd issue template.
+            Create the PRD as a GitHub issue.
             Then post a comment on the source RFC issue linking to the new PRD issue.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +99,7 @@ jobs:
             This is a PRD. Break it into tracer-bullet vertical slices:
             1. Explore the codebase to understand the current architecture
             2. Break the PRD into thin end-to-end slices (NOT horizontal layers)
-            3. Create each slice as a GitHub issue using the prd-to-issues issue template
+            3. Create each slice as a GitHub issue
             4. Create issues in dependency order so blockers exist before dependent issues reference them
 
             Do not ask for approval — create the issues directly.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/skill-chain.yml` — a GitHub Actions workflow that triggers on issue creation and routes work through the Claude agent/skill chain

## Test plan
- [ ] Workflow file is valid YAML and parses correctly in GitHub Actions
- [ ] Workflow triggers on `issues: opened` events as expected
- [ ] Bot-created issues are skipped (`sender.type != 'Bot'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)