### PR TITLE
fix: trigger RFC→PRD workflow on labeled event

### DIFF
--- a/.github/workflows/on-rfc.yml
+++ b/.github/workflows/on-rfc.yml
@@ -2,7 +2,7 @@ name: RFC → PRD
 
 on:
   issues:
-    types: [opened]
+    types: [opened, labeled]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Adds `labeled` to the `on.issues.types` trigger in `on-rfc.yml`
- Fixes the workflow being skipped when the `rfc` label is added after issue creation (the `opened` event fires before labels are applied)

## Test plan

- [ ] Create a new issue without the `rfc` label — workflow should not run
- [ ] Add the `rfc` label to an existing issue — workflow should now trigger and run the RFC → PRD job

🤖 Generated with [Claude Code](https://claude.com/claude-code)