### PR TITLE
fix: remove invalid workflows permission from on-slice

### DIFF
--- a/.github/workflows/on-slice.yml
+++ b/.github/workflows/on-slice.yml
@@ -9,7 +9,6 @@ permissions:
   issues: write
   pull-requests: write
   id-token: write
-  workflows: write
 
 jobs:
   implement-slice:


### PR DESCRIPTION
## Summary
- Reverts the invalid `workflows: write` permission added in #28
- `workflows` is not a valid `GITHUB_TOKEN` permission and breaks workflow validation
- Pushing workflow file changes requires a PAT or GitHub App token with `workflows` scope — a separate follow-up

## Test plan
- [ ] Workflow validation passes (no more "Unexpected value 'workflows'" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)